### PR TITLE
Changed start sequence and max 1s run

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -7,7 +7,8 @@ RZ is used and bit stuffing is used for transparency. After any
 sequence of four zeros (0000) a 1 must be inserted (00001).
 
 Bit stuffing is also used to prevent a continuous run of 1s from
-being interpreted as a frame start/end.
+being interpreted as a frame start/end. A sequence of more than 7 continuous 1s needs to have a
+zero added to it. For example, if you wanted to transmit 0xFF the encoded bits would be 0xFE1.
 
 ## Frames
 A total of 6 bytes are used for housekeeping per frame. Each frame can contain (theoretically) up to 4096 bits of
@@ -15,7 +16,7 @@ payload (4k bytes). The format is the following:
 
 | Start Flag    | To     | From   | Type   | Size        | Payload | CRC     |
 |---------------|--------|--------|--------|-------------|---------|---------|
- | 1 byte (0xFE) | 4 bits | 4 bits | 4 bits | 12 bits (N) | N bytes | 2 bytes |
+ | 1 byte (0xFF) | 4 bits | 4 bits | 4 bits | 12 bits (N) | N bytes | 2 bytes |
 
 ## Message types
 The following message types are reserved and should be interpreted in the same way by all implementations. The

--- a/tests/test_tx.cc
+++ b/tests/test_tx.cc
@@ -19,26 +19,27 @@ class TestBasebandTx : public testing::Test {
     /**
      * Transmit the specified data and store the transmitted bytes. This means transmitted bytes
      * may contain extra bits as the result of bit stuffing.
-     * @param buffer Transmitted bytes will be stored in this buffer. Bytes are grouped from left to right (MSB to LSB)
+     * @param buffer Transmitted bytes will be stored in this buffer. Bytes are grouped from left to right (MSB to LSB),
+     * and bits shifted from right to left as they are received.
      * @param data Bytes to be transmitted
      * @param data_size Amount of bytes to be transmitted
      * @param tx_func Function that will be used to transmit data
      */
     void runTxAndStore(uint8_t *buffer, uint8_t *data, uint8_t data_size, uint8_t (*tx_func)(uint8_t)) {
-        uint8_t tx_state, tx_nibble_end, counter, curr_nibble, curr_buffer, tx_global_end;
-        tx_nibble_end = counter = curr_nibble = curr_buffer = 0;
+        uint8_t tx_state, tx_end, counter, curr_block, curr_buffer, tx_global_end;
+        tx_end = counter = curr_block = curr_buffer = 0;
 
         tx_state = 1;
         while (tx_state != 0) {
             for (counter = 0; counter < 8; counter++) {
-                tx_nibble_end = tx_func(data[curr_nibble]);
-                tx_global_end = (tx_nibble_end == 0) && (curr_nibble == (data_size - 1));
+                tx_end = tx_func(data[curr_block]);
+                tx_global_end = (tx_end == 0) && (curr_block == (data_size - 1));
                 if ((counter < 7) && !tx_global_end) {
                     port = port << 1;
                 }
-                if (tx_nibble_end == 0) {
-                    curr_nibble++;
-                    if (curr_nibble == data_size) {
+                if (tx_end == 0) {
+                    curr_block++;
+                    if (curr_block == data_size) {
                         tx_state = 0;
                         break;
                     }
@@ -62,7 +63,7 @@ TEST_F(TestBasebandTx, RegisterTxFrameBusy) {
     ASSERT_EQ(tx_frame(frame), 1);
 }
 
-TEST_F(TestBasebandTx, TxBitOneZeroRun) {
+TEST_F(TestBasebandTx, TxBitZeroRun) {
     uint8_t retval;
     for (uint8_t counter = 0; counter < ZERO_LIMIT; counter++) {
         retval = tx_bit(0);
@@ -77,20 +78,19 @@ TEST_F(TestBasebandTx, TxBitOneZeroRun) {
     ASSERT_EQ(0x02, port);
 }
 
-TEST_F(TestBasebandTx, TxBitOneOneRun) {
+TEST_F(TestBasebandTx, TxBitOneRun) {
     uint8_t retval;
     for (uint8_t counter = 0; counter < ONE_LIMIT; counter++) {
         retval = tx_bit(1);
         port = port << 1;
     }
     ASSERT_EQ(0, retval);
-    ASSERT_EQ(0x3E, port);
+    ASSERT_EQ(0xFE, port);
     ASSERT_EQ(1, tx_bit(1));
-    ASSERT_EQ(0x3E, port);
+    ASSERT_EQ(0xFE, port);
 
-    port = port << 1;
     ASSERT_EQ(0, tx_bit(1));
-    ASSERT_EQ(0x7D, port);
+    ASSERT_EQ(0xFF, port);
 }
 
 TEST_F(TestBasebandTx, TxNibble) {
@@ -100,7 +100,7 @@ TEST_F(TestBasebandTx, TxNibble) {
     ASSERT_EQ(port, 0x03);
 }
 
-TEST_F(TestBasebandTx, TxNibblesWithOneZeroRun) {
+TEST_F(TestBasebandTx, TxNibblesWithZeroRun) {
     uint8_t buffer[2] = {0};
     uint8_t nibbles[2] = {0x06, 0x01};
     uint8_t expected_buffer[2] = {0x61, 0x01};
@@ -111,21 +111,21 @@ TEST_F(TestBasebandTx, TxNibblesWithOneZeroRun) {
     }
 }
 
-TEST_F(TestBasebandTx, TxNibblesWithOneOneRun) {
+TEST_F(TestBasebandTx, TxNibblesWithOneRun) {
     uint8_t buffer[2] = {0};
-    uint8_t nibbles[2] = {0x0B, 0x0F};
-    uint8_t expected_buffer[2] = {0xBE, 0x01};
+    uint8_t nibbles[3] = {0x05, 0x0F, 0x0F};
+    uint8_t expected_buffer[2] = {0x5F, 0x1B};
 
-    this->runTxAndStore(buffer, nibbles, 2, &tx_nibble);
+    this->runTxAndStore(buffer, nibbles, 3, &tx_nibble);
     for (uint8_t counter = 0; counter < 2; counter++) {
         ASSERT_EQ(expected_buffer[counter], buffer[counter]);
     }
 }
 
-TEST_F(TestBasebandTx, TxBytesWithOneOneRun) {
+TEST_F(TestBasebandTx, TxBytesWithOneRun) {
     uint8_t buffer[3] = {0};
-    uint8_t bytes[2] = {0xF5, 0xFB};
-    uint8_t expected_buffer[3] = {0xF5, 0xF5, 0x01};
+    uint8_t bytes[2] = {0xF5, 0xFD};
+    uint8_t expected_buffer[3] = {0xF5, 0xFC, 0x01};
 
     this->runTxAndStore(buffer, bytes, 2, &tx_byte);
     for (uint8_t counter = 0; counter < 3; counter++) {
@@ -133,7 +133,7 @@ TEST_F(TestBasebandTx, TxBytesWithOneOneRun) {
     }
 }
 
-TEST_F(TestBasebandTx, TxBytesWithOneZeroRun) {
+TEST_F(TestBasebandTx, TxBytesWithZeroRun) {
     uint8_t buffer[3] = {0};
     uint8_t bytes[2] = {0x8C, 0x1A};
     uint8_t expected_buffer[3] = {0x8C, 0x2D, 0x00};
@@ -155,7 +155,7 @@ TEST_F(TestBasebandTx, TxFrameTXRQ) {
 
     uint8_t tx_state, end, buffer_idx;
     uint8_t buffer[8] = {0};
-    uint8_t expected_bytes[] = {0xFE, 0x71, 0x10, 0x84, 0x6A, 0x95, 0x55, 0x01};
+    uint8_t expected_bytes[] = {0xFF, 0x71, 0x10, 0x84, 0x6A, 0x95, 0x55, 0x01};
 
     buffer_idx = 0;
     tx_state = 1;


### PR DESCRIPTION
The first iteration of the transmission protocol uses unipolar RZ where long sequences of 1s do not affect line code transparency, it was also decided that there was no good reason for the frame's start flags to be 0xFE instead of 0xFF.

Therefore the start flag is now 0xFF and the maximum run of 1s was limited to 7 just to prevent them from being interpreted as start flags.